### PR TITLE
Add pciutils dependency and copy set_dri_name script

### DIFF
--- a/scripts/Dockerfile.dependencies_humble
+++ b/scripts/Dockerfile.dependencies_humble
@@ -40,7 +40,8 @@ RUN apt-get update && apt-get install -y \
   lsb-release \
   sudo \
   net-tools \
-  && rm -rf /var/lib/apt/lists/* 
+  pciutils \
+  && rm -rf /var/lib/apt/lists/*
 
 # Install ROS2 and ROS packages
 RUN curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -o /usr/share/keyrings/ros-archive-keyring.gpg \
@@ -159,7 +160,7 @@ RUN curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -o 
     ros-humble-py-trees \
     ros-humble-py-trees-ros
 
-# PX4 pip installs 
+# PX4 pip installs
 RUN python3.10 -m pip install jsonschema==4.18.0
 
 # PX4 Dependencies
@@ -171,7 +172,7 @@ RUN apt-get update && apt-get install -y \
     ninja-build \
     rsync \
     shellcheck \
-  && rm -rf /var/lib/apt/lists/* 
+  && rm -rf /var/lib/apt/lists/*
 
 # Install PX4
 RUN git clone -b v1.14.0 https://github.com/PX4/PX4-Autopilot.git --recursive \

--- a/scripts/Dockerfile.humble
+++ b/scripts/Dockerfile.humble
@@ -19,11 +19,11 @@ ARG RAM=$RAM
 RUN git clone https://github.com/JdeRobot/RoboticsApplicationManager.git -b $RAM /RoboticsApplicationManager
 
 # copy scripts
-RUN mv -t / /opt/jderobot/scripts/.env  /opt/jderobot/scripts/entrypoint.sh /opt/jderobot/scripts/start_vnc.sh  /opt/jderobot/scripts/start_vnc_gpu.sh /opt/jderobot/scripts/kill_all.sh /opt/jderobot/scripts/test/check_device.py
+RUN mv -t / /opt/jderobot/scripts/.env  /opt/jderobot/scripts/entrypoint.sh /opt/jderobot/scripts/start_vnc.sh  /opt/jderobot/scripts/start_vnc_gpu.sh /opt/jderobot/scripts/kill_all.sh /opt/jderobot/scripts/test/check_device.py /opt/jderobot/scripts/set_dri_name.sh
 
 # give execution permissions
 WORKDIR /
-RUN chmod +x /start_vnc.sh /kill_all.sh /entrypoint.sh /start_vnc_gpu.sh
+RUN chmod +x /start_vnc.sh /kill_all.sh /entrypoint.sh /start_vnc_gpu.sh /set_dri_name.sh
 
 # RoboticsAcademy
 ARG ROBOTICS_ACADEMY=$ROBOTICS_ACADEMY


### PR DESCRIPTION
Depends on https://github.com/JdeRobot/RoboticsInfrastructure/pull/442

### set_dri_name.sh
This script sets the `DRI_NAME` environment variable depending on the available GPUs, which could reduce the `docker run` command complexity by freeing users from having to check which devices are available and manually setting their paths (it is meant to be called within [entrypoint.sh](https://github.com/JdeRobot/RoboticsInfrastructure/blob/43f128ca8e012d61f84dbd8fcff762027e5f5167/scripts/entrypoint.sh)). The only extra dependency is `pciutils`.

It yields traces about whether or not a GPU has been selected and its vendor. By default, the script prioritizes Nvidia, then Intel, then anything else. This default behavior can be overriden by passing the preferred vender as argument (e.g. `source set_dri_name.sh amd`)

Real example in a laptop with dual GPU configuration:
```
$ source set_dri_name.sh 
Vendor: nvidia
DRI_NAME: card1
$ source set_dri_name.sh intel
Vendor: intel
DRI_NAME: card0
$ source set_dri_name.sh asdga
Error: No GPU found for the vendor 'asdga'.
```